### PR TITLE
Update for BouncyCastle 1.58 Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
   	<kettle.version>6.1.0.3-223</kettle.version>
-  	<bouncycastle.version>1.57</bouncycastle.version>
+  	<bouncycastle.version>1.58</bouncycastle.version>
   </properties>
 
   <dependencies>
@@ -70,7 +70,7 @@
   <repositories>
     <repository>
       <id>Pentaho Artifactory</id>
-      <url>http://repo.pentaho.org/artifactory/repo</url>
+      <url>http://nexus.pentaho.org/content/groups/omni</url>
     </repository>
   </repositories>
   

--- a/src/test/java/com/github/matthewtckr/pdi/steps/encryption/CryptoHashStepDataTest.java
+++ b/src/test/java/com/github/matthewtckr/pdi/steps/encryption/CryptoHashStepDataTest.java
@@ -31,18 +31,18 @@ public class CryptoHashStepDataTest {
     String encryptedPassword = data.bcrypt( "password" );
     assertThat( encryptedPassword, notNullValue() );
     assertThat( encryptedPassword.length(), either( equalTo( 59 ) ).or( equalTo( 60 ) ) );
-    assertThat( encryptedPassword, startsWith( "$2a$" ) );
+    assertThat( encryptedPassword, startsWith( "$2y$" ) );
 
     encryptedPassword = data.bcrypt( "61626300", 9 );
     assertThat( encryptedPassword, notNullValue() );
     assertThat( encryptedPassword.length(), either( equalTo( 59 ) ).or( equalTo( 60 ) ) );
-    assertThat( encryptedPassword, startsWith( "$2a$09$" ) );
+    assertThat( encryptedPassword, startsWith( "$2y$09$" ) );
     
     byte[] salt = new BigInteger( 127, new Random() ).toByteArray(); // Random 16-byte salt
     encryptedPassword = data.bcrypt( "61626300", salt, 9 );
     assertThat( encryptedPassword, notNullValue() );
     assertThat( encryptedPassword.length(), either( equalTo( 59 ) ).or( equalTo( 60 ) ) );
-    assertThat( encryptedPassword, startsWith( "$2a$09$" ) );
+    assertThat( encryptedPassword, startsWith( "$2y$09$" ) );
   }
 
   @Test
@@ -69,7 +69,10 @@ public class CryptoHashStepDataTest {
 
   @Test
   public void testEncrypt() throws KettleStepException {
+    // NULL CryptoHashType returns original value
     assertThat( data.encrypt( "123456", (CryptoHashType) null, 12 ), equalTo( "123456" ) );
+
+    // Non-NULL CryptoHashType does not return original value
     for ( CryptoHashType method : CryptoHashType.values() ) {
       assertThat( data.encrypt( "123456", method, 12 ), not( equalTo( "123456" ) ) );
     }


### PR DESCRIPTION
BouncyCastle 1.58 [added support for "2y" versions](https://github.com/bcgit/bc-java/commit/8941441e6944ee5ce3ffa37e161345e4764f2929) of Bcrypt strings.  Updated test cases to accept the new default format.